### PR TITLE
Update plugin to work with Gatsby v3, WebPack v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "gatsby": "^3.0.0"
   },
   "dependencies": {
-    "workerize-loader-wp5": "^2.0.0"
+    "workerize-loader-wp5": "^2.0.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.1",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "webpack"
   ],
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "^3.0.0"
   },
   "dependencies": {
-    "workerize-loader": "^1.3.0"
+    "workerize-loader-wp5": "^2.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.1",

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -10,9 +10,8 @@ exports.onCreateWebpackConfig = ({
   let options = {}
 
   if (stage === 'build-javascript') {
-    config.optimization.moduleIds = 'total-size'
     options = {
-      name: `${PREFIX}-[1].[hash:6]`,
+      name: `${PREFIX}-[1].[contenthash]`,
       regExp: '(\\w+).worker.(js|ts|coffee)$',
     }
   }
@@ -21,8 +20,6 @@ exports.onCreateWebpackConfig = ({
     test: /\.worker\.(js|ts|coffee)$/,
     use: { loader: 'workerize-loader', options },
   })
-
-  config.output.globalObject = 'this'
 
   replaceWebpackConfig(config)
 }

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -18,7 +18,7 @@ exports.onCreateWebpackConfig = ({
 
   config.module.rules.push({
     test: /\.worker\.(js|ts|coffee)$/,
-    use: { loader: 'workerize-loader', options },
+    use: { loader: 'workerize-loader-wp5', options },
   })
 
   replaceWebpackConfig(config)

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -13,6 +13,8 @@ let preloadScripts = []
 
 // For some reason, this does not work as expected on Chrome.
 // So for now, I'm not mentioning preloads option in README.
+//
+// Be aware that adding preloads will prevent Gatsby to use the `GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES` flag
 exports.onRenderBody = ({ setHeadComponents }, { preloads = [] } = {}) => {
   if (!preloads.length) return
 


### PR DESCRIPTION
If approved, this pull request will:

- Change the dependency from `workerize-loader` to `workerize-loader-wp5`
- Update the peer dependency version of Gatsby to ^3.0.0
- Update the WebPack config to use `contenthash` instead of the deprecated `total-sizes`

This fixes [issue 6](https://github.com/universse/gatsby-plugin-workerize-loader/issues/6)